### PR TITLE
Validate audio server started

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,21 +11,22 @@ echo missed-moment install starting...
 
 cd $HOME
 echo Updating OS and installing system dependencies...
-sudo apt update
+sudo apt-get update
 
 # video
-sudo apt -y install gpac
+sudo apt-get -y install gpac
 
 # USB
-sudo apt -y install exfat-fuse
+sudo apt-get -y install exfat-fuse
 
 # audio server
-sudo apt -y install jackd2
+sudo apt-get -y install jackd2
 # modify /etc/security/limits.d/audio.conf to bring realtime priorities to the audio group (which is usually fine for a single user desktop usage)
+# the audio.conf file already exists now, keep here
 sudo mv /etc/security/limits.d/audio.conf.disabled /etc/security/limits.d/audio.conf
 # audio capture
-sudo apt -y install liblo-tools
-sudo apt -y install jack-capture
+sudo apt-get -y install liblo-tools
+sudo apt-get -y install jack-capture
 
 echo Downloading missed-moment...
 curl -L https://github.com/oudeismetis/missed-moment/archive/master.zip > missed-moment-master.zip

--- a/missed-moment.py
+++ b/missed-moment.py
@@ -231,9 +231,12 @@ def main():
 
             # make sure audio server is running before starting audio capture client
             is_running = False
-            while not check_audio_server_running():
-                logging.debug("audio server not running yet, waiting...")
-                is_running = True
+            while not is_running:
+                result = check_audio_server_running()
+                if result:
+                    is_running = True
+                else:
+                    logging.debug("audio server not running yet, waiting...")
 
             # start audio capture buffer
             start_audio_capture_ringbuffer()


### PR DESCRIPTION
1.  Validate audio server started - added a check to see if the process was running and that was not good enough as the process could be running but the audio server was still not fully started.  So added a wait after issuing the command as well.  The audio server is only started once when running missed_moment so I think this is ok.

After both things, set/reset the video and audio.  

2. Change apt to apt-get in scripts.  apt-get is meant for use in scripts and gets a warning if you use apt.  apt is meant for command line outside of scripts.
3. Make note that mv audio.conf not needed
4. Have jack only do capture (and -C) so get rid of warning "ALSA: Cannot open PCM device alsa_pcm for playback. Falling back to capture-only mode"
jackd -P70 -p16 -t2000 -dalsa -C -dhw:1,0 -p128 -n3 -r44100 -s &

5. Stop jack server any time in finally (break out in function).  I moved finally out in a bigger block than just the recording part.